### PR TITLE
fix(http): wrong int type in httpring handler

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -2298,7 +2298,7 @@ void WalterModem::_processQueueRsp(WalterModemCmd *cmd, WalterModemBuffer *buff)
         char *start = (char *)rspStr + _strLitLen("+SQNHTTPRING: ");
 
         uint8_t profileId = 0;
-        uint8_t httpStatus = 0;
+        uint16_t httpStatus = 0;
         char *contentType = NULL;
         uint16_t contentLength = 0;
 

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2203,7 +2203,7 @@ typedef struct {
     /**
      * @brief Last incoming ring: http status code
      */
-    uint8_t httpStatus;
+    uint16_t httpStatus;
 
     /**
      * @brief Last incoming ring: length


### PR DESCRIPTION
fixed a bug where the max value of an error code could only be 255