### PR TITLE
fix(socket-tls-examples): updated examples to disable tls by default

### DIFF
--- a/examples/Positioning/Positioning.ino
+++ b/examples/Positioning/Positioning.ino
@@ -349,8 +349,18 @@ bool updateGNSSAssistance()
 bool socketConnect(const char *ip, uint16_t port)
 {
   /* Construct a socket */
-  if(!modem.socketConfig()) {
+  if(modem.socketConfig()) {
+    Serial.print("Created a new socket\r\n");
+  } else {
     Serial.print("Could not create a new socket\r\n");
+    return false;
+  }
+
+  /* disable socket tls as the demo server does not use it */
+  if(modem.socketConfigTLS(-1, 1, false)) {
+    Serial.print("Configured TLS\r\n");
+  } else {
+    Serial.print("Could not configure TLS\r\n");
     return false;
   }
 

--- a/examples/WalterFeels/WalterFeels.ino
+++ b/examples/WalterFeels/WalterFeels.ino
@@ -457,6 +457,14 @@ void modem_transmit() {
     Serial.println("Error: Could not configure the socket");
   }
 
+  /* disable socket tls as the demo server does not use it */
+  if(modem.socketConfigTLS(-1, 1, false)) {
+    Serial.print("Configured TLS\r\n");
+  } else {
+    Serial.print("Could not configure TLS\r\n");
+    return;
+  }
+
   if (modem.socketDial(SERV_ADDR, SERV_PORT, SERV_PORT)) {
     Serial.printf("Connected to UDP server %s:%d\r\n", SERV_ADDR, SERV_PORT);
   } else {

--- a/examples/tcp_socket_receive/tcp_socket_receive.ino
+++ b/examples/tcp_socket_receive/tcp_socket_receive.ino
@@ -208,6 +208,14 @@ void setup() {
     return;
   }
 
+  /* disable socket tls as the demo server does not use it */
+  if(modem.socketConfigTLS(-1, 1, false)) {
+    Serial.print("Configured TLS\r\n");
+  } else {
+    Serial.print("Could not configure TLS\r\n");
+    return;
+  }
+
   /* Connect to the demo server */
   if (modem.socketDial(SERV_ADDR, SERV_PORT, 0, NULL, NULL, NULL,
                        WALTER_MODEM_SOCKET_PROTO_TCP)) {

--- a/examples/udp_socket/udp_socket.ino
+++ b/examples/udp_socket/udp_socket.ino
@@ -193,6 +193,14 @@ void setup() {
     Serial.println("Error: Could not connect the socket");
   }
 
+  /* disable socket tls as the demo server does not use it */
+  if(modem.socketConfigTLS(-1, 1, false)) {
+    Serial.print("Configured TLS\r\n");
+  } else {
+    Serial.print("Could not configure TLS\r\n");
+    return;
+  }
+
   /* Connect to the UDP test server */
   if (modem.socketDial(SERV_ADDR, SERV_PORT)) {
     Serial.printf("Connected to UDP server %s:%d\r\n", SERV_ADDR, SERV_PORT);


### PR DESCRIPTION
This PR updates the socket examples to disable TLS by default, ensuring they run out-of-the-box in a typical development environment without requiring certificate setup. This is because once TLS is configured, it is persistently active.