### PR TITLE
fix(socket): updated examples and bluecherry socket implementation

### DIFF
--- a/examples/Positioning/Positioning.ino
+++ b/examples/Positioning/Positioning.ino
@@ -357,7 +357,7 @@ bool socketConnect(const char *ip, uint16_t port)
   }
 
   /* disable socket tls as the demo server does not use it */
-  if(modem.socketConfigTLS(-1, 1, false)) {
+  if(modem.socketConfigSecure(false)) {
     Serial.print("Configured TLS\r\n");
   } else {
     Serial.print("Could not configure TLS\r\n");

--- a/examples/WalterFeels/WalterFeels.ino
+++ b/examples/WalterFeels/WalterFeels.ino
@@ -458,7 +458,7 @@ void modem_transmit() {
   }
 
   /* disable socket tls as the demo server does not use it */
-  if(modem.socketConfigTLS(-1, 1, false)) {
+  if(modem.socketConfigSecure(false)) {
     Serial.print("Configured TLS\r\n");
   } else {
     Serial.print("Could not configure TLS\r\n");

--- a/examples/bluecherry/bluecherry.ino
+++ b/examples/bluecherry/bluecherry.ino
@@ -140,17 +140,12 @@ bool lteConnect() {
 
   delay(1000);
 
-  if (!modem.setNetworkAttachmentState(false)) {
-    Serial.println("Error: Could not set the modem attachment state to false");
-    return false;
-  }
-
-  delay(500);
-
   // Set the network operator selection to automatic
-  if (!modem.setNetworkSelectionMode(WALTER_MODEM_NETWORK_SEL_MODE_MANUAL, "20601", WALTER_MODEM_OPERATOR_FORMAT_NUMERIC)) {
-    Serial.println("Error: Could not set the network selection mode to manual");
-    return false;
+  if (modem.setNetworkSelectionMode(WALTER_MODEM_NETWORK_SEL_MODE_AUTOMATIC)) {
+      Serial.println("Network selection mode to was set to automatic");
+  } else {
+      Serial.println("Error: Could not set the network selection mode to automatic");
+      return false;
   }
 
   // Wait (maximum 5 minutes) until successfully registered to the network

--- a/examples/tcp_socket_receive/tcp_socket_receive.ino
+++ b/examples/tcp_socket_receive/tcp_socket_receive.ino
@@ -209,7 +209,7 @@ void setup() {
   }
 
   /* disable socket tls as the demo server does not use it */
-  if(modem.socketConfigTLS(-1, 1, false)) {
+  if(modem.socketConfigSecure(false)) {
     Serial.print("Configured TLS\r\n");
   } else {
     Serial.print("Could not configure TLS\r\n");

--- a/examples/udp_socket/udp_socket.ino
+++ b/examples/udp_socket/udp_socket.ino
@@ -194,7 +194,7 @@ void setup() {
   }
 
   /* disable socket tls as the demo server does not use it */
-  if(modem.socketConfigTLS(-1, 1, false)) {
+  if(modem.socketConfigSecure(false)) {
     Serial.print("Configured TLS\r\n");
   } else {
     Serial.print("Could not configure TLS\r\n");


### PR DESCRIPTION
Updated the socket examples to use the refactored name for the TLS configuration.
Updated the bluecherry sync implementation to use the new method signature also.
Updated bluecherry example to once again have automatic network selection.