### PR TITLE
fix(bluecherry-init): added bluecherry coap port to kconfig constants

### DIFF
--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -258,6 +258,8 @@ CONFIG_UINT8(WALTER_MODEM_MAX_SOCKET_RINGS, 8)
  * @brief The default hostname for Bluecherry.
  */
 CONFIG(WALTER_MODEM_BLUE_CHERRY_HOSTNAME, const char *, "coap.bluecherry.io")
+
+CONFIG(WALTER_MODEM_BLUE_CHERRY_PORT, uint16_t, 5684)
 #endif
 
 /**
@@ -3117,7 +3119,7 @@ private:
     /*
      * @brief The current BlueCherry state.
      */
-    static inline WalterModemBlueCherryState _blueCherry;
+    static inline WalterModemBlueCherryState _blueCherry = {};
 #endif
 
 #pragma region MOTA

--- a/src/proto/WalterBlueCherry.cpp
+++ b/src/proto/WalterBlueCherry.cpp
@@ -109,9 +109,10 @@ bool WalterModem::_blueCherrySocketConfigure()
     if(!socketConfigSecure(true, _blueCherry.tlsProfileId, _blueCherry.bcSocketId)) {
         return false;
     }
+
     if(!socketDial(
         WALTER_MODEM_BLUE_CHERRY_HOSTNAME,
-        _blueCherry.port,
+        WALTER_MODEM_BLUE_CHERRY_PORT,
         0,
         NULL,
         NULL,
@@ -135,18 +136,11 @@ void WalterModem::_blueCherrySocketEventHandler(WalterModemSocketEvent event, ui
                 _blueCherry.status = WALTER_MODEM_BLUECHERRY_STATUS_RESPONSE_READY;
             }
             break;
+
         case WALTER_MODEM_SOCKET_EVENT_DISCONNECTED:
-            // Dial the host over the socket if the connection was not yet established or dropped.
-            socketDial(
-                WALTER_MODEM_BLUE_CHERRY_HOSTNAME,
-                _blueCherry.port,
-                0,
-                NULL,
-                NULL,
-                NULL,
-                WALTER_MODEM_SOCKET_PROTO_UDP,
-                WALTER_MODEM_ACCEPT_ANY_REMOTE_DISABLED,
-                _blueCherry.bcSocketId);
+            _blueCherry.bcSocketId = 0;
+            _blueCherrySocketConfigure();
+
         case WALTER_MODEM_SOCKET_EVENT_CONNECTED:
         default:
             break;


### PR DESCRIPTION
Fixed a nasty little bug where the static inline port variable would not be initialized, so we ;oved it into a kconfig constant