### PR TITLE
fix(bluecherry-example): Remove delay before deep sleep

### DIFF
--- a/examples/bluecherry/bluecherry.ino
+++ b/examples/bluecherry/bluecherry.ino
@@ -343,9 +343,6 @@ void loop() {
   // Poll BlueCherry platform if an incoming message or firmware update is available
   syncBlueCherry();
 
-  // Wait for PSM to become active
-  delay(20000);
-
   // Go sleep for a minute
   modem.sleep(60);
 }


### PR DESCRIPTION
Removes unnecessary and possibly confusing delay before entering ESP32S3 deep sleep.