### PR TITLE
fix(bluecherry, parser): reworked bluecherry reconnect implementation and RX parser logic

### DIFF
--- a/examples/bluecherry/bluecherry.ino
+++ b/examples/bluecherry/bluecherry.ino
@@ -193,7 +193,6 @@ void syncBlueCherry() {
           rsp.data.blueCherry.state);
       modem.reset();
       lteConnect();
-      modem.blueCherryInit(BC_TLS_PROFILE, otaBuffer);
       return;
     }
 
@@ -343,6 +342,6 @@ void loop() {
   // Poll BlueCherry platform if an incoming message or firmware update is available
   syncBlueCherry();
 
-  // Go sleep for a minute
-  modem.sleep(60);
+  // Go sleep for 5 minutes
+  modem.sleep(60 * 5);
 }

--- a/src/proto/WalterCoAP.cpp
+++ b/src/proto/WalterCoAP.cpp
@@ -101,8 +101,6 @@ bool WalterModem::coapDidRing(
         _coapContextSet[profileId].rings[ringIdx].messageId,
         _coapContextSet[profileId].rings[ringIdx].length);
         
-    _receiving = true;
-    _receiveExpected = _coapContextSet[profileId].rings[ringIdx].length;
     _runCmd(
         arr((const char *)stringsBuffer->data),
         "OK",

--- a/src/proto/WalterHTTP.cpp
+++ b/src/proto/WalterHTTP.cpp
@@ -347,7 +347,6 @@ bool WalterModem::httpDidRing(
         _httpContextSet[_httpCurrentProfile].state = WALTER_MODEM_HTTP_CONTEXT_STATE_IDLE;
         _httpCurrentProfile = 0xff;
     };
-    _receiving = true;
     _runCmd(
         arr("AT+SQNHTTPRCV=", _atNum(profileId)),
         "OK",

--- a/src/proto/WalterMQTT.cpp
+++ b/src/proto/WalterMQTT.cpp
@@ -227,7 +227,6 @@ bool WalterModem::mqttDidRing(
     if (targetBufSize < _mqttRings[idx].length) {
         _returnState(WALTER_MODEM_STATE_NO_MEMORY);
     }
-    _receiving = true;
 
     if (_mqttRings[idx].qos == 0) {
         /* no msg id means qos 0 message */

--- a/src/proto/WalterSocket.cpp
+++ b/src/proto/WalterSocket.cpp
@@ -475,18 +475,15 @@ bool WalterModem::socketReceive(
         return true;
     }
 
-    _receiving = true;
-    _receiveExpected = dataToRead;
-    sock->dataAvailable -= dataToRead;
     _runCmd(
         arr("AT+SQNSRECV=", _digitStr(sock->id), ",", _atNum(receiveCount)),
-        "OK",
+        "+SQNSRECV:",
         rsp,
         cb,
         args,
         NULL,
         NULL,
-        WALTER_MODEM_CMD_TYPE_TX_WAIT,
+        WALTER_MODEM_CMD_TYPE_DATA_TX_WAIT,
         targetBuf,
         targetBufSize);
     _returnAfterReply();
@@ -496,6 +493,10 @@ WalterModemSocketState WalterModem::socketGetState(int socketId)
 {
     if(!_socketUpdateStates()){
         ESP_LOGW("WalterModem", "Could not update socket states");
+    }
+
+    if (socketId == 0) {
+        return WalterModemSocketState::WALTER_MODEM_SOCKET_STATE_FREE;
     }
 
     WalterModemSocket *sock = _socketGet(socketId);


### PR DESCRIPTION
# Bluecherry

- Added default bluecherry state WALTER_MODEM_BLUECHERRY_STATUS_NOT_CONNECTED = 0
- Now checks socket status and reconnects / re-diales the socket automatically on call to bluecherrySync
- Event handler will only process the CoAP message if it expects to receive one

# RX Parser

- Moved _receivingPayload flag and _receiveExpected counter inside the RX parser thread
- Socket receive method _runCmd expects +SQNSRECV: return instead of OK

# Bluecherry Example

- Removed excessive bluecherryInit method after bluecherrySync fails
- Increased sleep timer to 5 minutes