### PR TITLE
fix(parser): expected payload size as fallback to received payload length parser

### DIFF
--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2932,7 +2932,9 @@ private:
 
     static inline size_t currentCRLF = 0;
 
-    static inline size_t _receiveExpected = 0;
+    static inline size_t _receivedPayloadSize = 0;
+
+    static inline size_t _expectedPayloadSize = 0;
     /**
      * @brief We remember the configured watchdog timeout.
      */

--- a/src/proto/WalterCoAP.cpp
+++ b/src/proto/WalterCoAP.cpp
@@ -100,7 +100,10 @@ bool WalterModem::coapDidRing(
         profileId,
         _coapContextSet[profileId].rings[ringIdx].messageId,
         _coapContextSet[profileId].rings[ringIdx].length);
-        
+
+    // The number of received bytes attempts to be read from within the RX parser.
+    // This will be used as a fallback if it cannot read it.
+    _expectedPayloadSize = _coapContextSet[profileId].rings[ringIdx].length;       
     _runCmd(
         arr((const char *)stringsBuffer->data),
         "OK",

--- a/src/proto/WalterSocket.cpp
+++ b/src/proto/WalterSocket.cpp
@@ -475,6 +475,9 @@ bool WalterModem::socketReceive(
         return true;
     }
 
+    // The number of received bytes attempts to be read from within the RX parser.
+    // This will be used as a fallback if it cannot read it.
+    _expectedPayloadSize = dataToRead;
     _runCmd(
         arr("AT+SQNSRECV=", _digitStr(sock->id), ",", _atNum(receiveCount)),
         "+SQNSRECV:",


### PR DESCRIPTION
The expectingPayload() method now first checks if the RX response contains a prefix expected to contain payload data, and will then attempt to extract the length from it. If this fails (due to unexpected response parameters) it will fall back to the expected payload size set in the transmit (TX)