### PR TITLE
fix(MQTT): mqttConfig memory stability for multiple calls

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -987,6 +987,10 @@ WalterModemBuffer *WalterModem::_getFreeBuffer(void)
         }
     }
 
+    if (chosenBuf == NULL) {
+        ESP_LOGE("WalterModem", "No free buffers");
+    }
+
     return chosenBuf;
 }
 
@@ -1489,7 +1493,7 @@ TickType_t WalterModem::_processQueueCmd(WalterModemCmd *cmd, bool queueError)
                 if (timedOut) {
                     ESP_LOGW("WalterModem", "Command time-out (TX) Attempt %u of %u", cmd->attempt, cmd->maxAttempts);
                 } else {
-                    ESP_LOGW("WalterModem", "Command ERROR (TX) Attempt %u of %u", cmd->attempt, cmd->maxAttempts);
+                    ESP_LOGD("WalterModem", "Command ERROR (TX) Attempt %u of %u", cmd->attempt, cmd->maxAttempts);
                 }
                 _resetParseRxFlags();
                 if (cmd->attempt >= cmd->maxAttempts) {

--- a/src/proto/WalterMQTT.cpp
+++ b/src/proto/WalterMQTT.cpp
@@ -105,7 +105,18 @@ bool WalterModem::mqttConfig(
         buf->size += sprintf((char*) buf->data + buf->size, ",%u", tlsProfileId);
     }
     
-    _runCmd(arr((const char*) buf->data), "OK", rsp, cb, args);
+    _runCmd(
+        arr((const char*) buf->data),
+        "OK",
+        rsp,
+        cb,
+        args,
+        NULL,
+        NULL,
+        WALTER_MODEM_CMD_TYPE_TX_WAIT,
+        NULL,
+        0,
+        buf);
     _returnAfterReply();
 }
 


### PR DESCRIPTION
Added a buffer reference to the runCmd so that it knows to free that buffer after the command was executed.
This caused "Memory leaks" inside the buffer when calling mqttConfig multiple times.

Added an error log whenever no free buffer is available. There is no handling for this so this error will likely precede a panic.