### PR TITLE
example(UDP/TCP): Validity check for cellinfo added

### DIFF
--- a/examples/tcp/tcp.ino
+++ b/examples/tcp/tcp.ino
@@ -55,6 +55,7 @@
 #define TCP_HOST "walterdemo.quickspot.io"
 
 #define BASIC_INFO_PACKET_SIZE 24
+#define COUNTER_PACKET_SIZE 8
 
 /**
  * @brief The modem instance.
@@ -219,46 +220,55 @@ void tcpSocketEventHandler(WalterModemSocketEvent ev, int socketId, uint16_t dat
  */
 bool tcpSendBasicInfoPacket()
 {
-  /* Read the temperature of Walter */
-  float temp = temperatureRead();
-  uint16_t rawTemp = (temp + 50) * 100;
+  uint16_t packet_size = COUNTER_PACKET_SIZE;
 
-  uint8_t rat = -1;
-  if(modem.getRAT(&rsp)) {
-    rat = (uint8_t) rsp.data.rat;
+  dataBuf[6] = counter >> 8;
+  dataBuf[7] = counter & 0xFF;
+
+  /* Only send the full packet if cellinfo is valid */
+  if(rsp.data.cellInformation.cc != 0 || rsp.data.cellInformation.nc != 0 ||
+     rsp.data.cellInformation.tac != 0 || rsp.data.cellInformation.cid != 0) {
+    packet_size = BASIC_INFO_PACKET_SIZE;
+
+    /* Read the temperature of Walter */
+    float temp = temperatureRead();
+    uint16_t rawTemp = (temp + 50) * 100;
+
+    uint8_t rat = -1;
+    if(modem.getRAT(&rsp)) {
+      rat = (uint8_t) rsp.data.rat;
+    }
+
+    /* Construct the basic info packet */
+    dataBuf[8] = rawTemp >> 8;
+    dataBuf[9] = rawTemp & 0xFF;
+    dataBuf[10] = rsp.data.cellInformation.cc >> 8;
+    dataBuf[11] = rsp.data.cellInformation.cc & 0xFF;
+    dataBuf[12] = rsp.data.cellInformation.nc >> 8;
+    dataBuf[13] = rsp.data.cellInformation.nc & 0xFF;
+    dataBuf[14] = rsp.data.cellInformation.tac >> 8;
+    dataBuf[15] = rsp.data.cellInformation.tac & 0xFF;
+    dataBuf[16] = (rsp.data.cellInformation.cid >> 24) & 0xFF;
+    dataBuf[17] = (rsp.data.cellInformation.cid >> 16) & 0xFF;
+    dataBuf[18] = (rsp.data.cellInformation.cid >> 8) & 0xFF;
+    dataBuf[19] = rsp.data.cellInformation.cid & 0xFF;
+    dataBuf[20] = (uint8_t) (rsp.data.cellInformation.rsrp * -1);
+    dataBuf[21] = (uint8_t) (rsp.data.cellInformation.rsrq * -1);
+    dataBuf[22] = rat;
+    dataBuf[23] = 0xFF;
   }
 
-  /* Construct the Basic info Packet */
-  dataBuf[6] = rawTemp >> 8;
-  dataBuf[7] = rawTemp & 0xFF;
-  dataBuf[8] = counter >> 8;
-  dataBuf[9] = counter & 0xFF;
-  dataBuf[10] = rsp.data.cellInformation.cc >> 8;
-  dataBuf[11] = rsp.data.cellInformation.cc & 0xFF;
-  dataBuf[12] = rsp.data.cellInformation.nc >> 8;
-  dataBuf[13] = rsp.data.cellInformation.nc & 0xFF;
-  dataBuf[14] = rsp.data.cellInformation.tac >> 8;
-  dataBuf[15] = rsp.data.cellInformation.tac & 0xFF;
-  dataBuf[16] = (rsp.data.cellInformation.cid >> 24) & 0xFF;
-  dataBuf[17] = (rsp.data.cellInformation.cid >> 16) & 0xFF;
-  dataBuf[18] = (rsp.data.cellInformation.cid >> 8) & 0xFF;
-  dataBuf[19] = rsp.data.cellInformation.cid & 0xFF;
-  dataBuf[20] = (uint8_t) (rsp.data.cellInformation.rsrp * -1);
-  dataBuf[21] = (uint8_t) (rsp.data.cellInformation.rsrq * -1);
-  dataBuf[22] = rat;
-  dataBuf[23] = 0xFF;
+  Serial.println("Sending packet...");
 
-  Serial.println("Sending basic info packet");
-
-  if(!modem.socketSend(dataBuf, BASIC_INFO_PACKET_SIZE)) {
-    Serial.println("Error: TCP send basic info packet failed");
+  if(!modem.socketSend(dataBuf, packet_size)) {
+    Serial.println("Error: TCP send packet failed");
     return false;
   }
 
   /* Attempt to get the latest cell information (for next packet) */
   modem.getCellInformation(WALTER_MODEM_SQNMONI_REPORTS_SERVING_CELL, &rsp);
 
-  Serial.println("TCP send basic info packet succeeded");
+  Serial.println("TCP send basic packet succeeded");
   return true;
 }
 

--- a/examples/udp/udp.ino
+++ b/examples/udp/udp.ino
@@ -218,7 +218,7 @@ void udpSocketEventHandler(WalterModemSocketEvent ev, int socketId, uint16_t dat
 /**
  * @brief Send a basic info packet to walterdemo
  */
-bool tcpSendBasicInfoPacket()
+bool udpSendBasicInfoPacket()
 {
   uint16_t packet_size = COUNTER_PACKET_SIZE;
 
@@ -344,7 +344,7 @@ void loop()
   if(millis() - lastSend >= sendInterval) {
     lastSend = millis();
 
-    if(!tcpSendBasicInfoPacket()) {
+    if(!udpSendBasicInfoPacket()) {
       Serial.println("UDP send failed, restarting...");
       delay(1000);
       ESP.restart();

--- a/examples/udp/udp.ino
+++ b/examples/udp/udp.ino
@@ -55,6 +55,7 @@
 #define UDP_HOST "walterdemo.quickspot.io"
 
 #define BASIC_INFO_PACKET_SIZE 24
+#define COUNTER_PACKET_SIZE 8
 
 /**
  * @brief The modem instance.
@@ -217,48 +218,57 @@ void udpSocketEventHandler(WalterModemSocketEvent ev, int socketId, uint16_t dat
 /**
  * @brief Send a basic info packet to walterdemo
  */
-bool udpSendBasicInfoPacket()
+bool tcpSendBasicInfoPacket()
 {
-  /* Read the temperature of Walter */
-  float temp = temperatureRead();
-  uint16_t rawTemp = (temp + 50) * 100;
+  uint16_t packet_size = COUNTER_PACKET_SIZE;
 
-  uint8_t rat = -1;
-  if(modem.getRAT(&rsp)) {
-    rat = (uint8_t) rsp.data.rat;
+  dataBuf[6] = counter >> 8;
+  dataBuf[7] = counter & 0xFF;
+
+  /* Only send the full packet if cellinfo is valid */
+  if(rsp.data.cellInformation.cc != 0 || rsp.data.cellInformation.nc != 0 ||
+     rsp.data.cellInformation.tac != 0 || rsp.data.cellInformation.cid != 0) {
+    packet_size = BASIC_INFO_PACKET_SIZE;
+
+    /* Read the temperature of Walter */
+    float temp = temperatureRead();
+    uint16_t rawTemp = (temp + 50) * 100;
+
+    uint8_t rat = -1;
+    if(modem.getRAT(&rsp)) {
+      rat = (uint8_t) rsp.data.rat;
+    }
+
+    /* Construct the basic info packet */
+    dataBuf[8] = rawTemp >> 8;
+    dataBuf[9] = rawTemp & 0xFF;
+    dataBuf[10] = rsp.data.cellInformation.cc >> 8;
+    dataBuf[11] = rsp.data.cellInformation.cc & 0xFF;
+    dataBuf[12] = rsp.data.cellInformation.nc >> 8;
+    dataBuf[13] = rsp.data.cellInformation.nc & 0xFF;
+    dataBuf[14] = rsp.data.cellInformation.tac >> 8;
+    dataBuf[15] = rsp.data.cellInformation.tac & 0xFF;
+    dataBuf[16] = (rsp.data.cellInformation.cid >> 24) & 0xFF;
+    dataBuf[17] = (rsp.data.cellInformation.cid >> 16) & 0xFF;
+    dataBuf[18] = (rsp.data.cellInformation.cid >> 8) & 0xFF;
+    dataBuf[19] = rsp.data.cellInformation.cid & 0xFF;
+    dataBuf[20] = (uint8_t) (rsp.data.cellInformation.rsrp * -1);
+    dataBuf[21] = (uint8_t) (rsp.data.cellInformation.rsrq * -1);
+    dataBuf[22] = rat;
+    dataBuf[23] = 0xFF;
   }
 
-  /* Construct the Basic info Packet */
-  dataBuf[6] = rawTemp >> 8;
-  dataBuf[7] = rawTemp & 0xFF;
-  dataBuf[8] = counter >> 8;
-  dataBuf[9] = counter & 0xFF;
-  dataBuf[10] = rsp.data.cellInformation.cc >> 8;
-  dataBuf[11] = rsp.data.cellInformation.cc & 0xFF;
-  dataBuf[12] = rsp.data.cellInformation.nc >> 8;
-  dataBuf[13] = rsp.data.cellInformation.nc & 0xFF;
-  dataBuf[14] = rsp.data.cellInformation.tac >> 8;
-  dataBuf[15] = rsp.data.cellInformation.tac & 0xFF;
-  dataBuf[16] = (rsp.data.cellInformation.cid >> 24) & 0xFF;
-  dataBuf[17] = (rsp.data.cellInformation.cid >> 16) & 0xFF;
-  dataBuf[18] = (rsp.data.cellInformation.cid >> 8) & 0xFF;
-  dataBuf[19] = rsp.data.cellInformation.cid & 0xFF;
-  dataBuf[20] = (uint8_t) (rsp.data.cellInformation.rsrp * -1);
-  dataBuf[21] = (uint8_t) (rsp.data.cellInformation.rsrq * -1);
-  dataBuf[22] = rat;
-  dataBuf[23] = 0xFF;
+  Serial.println("Sending packet...");
 
-  Serial.println("Sending basic info packet");
-
-  if(!modem.socketSend(dataBuf, BASIC_INFO_PACKET_SIZE)) {
-    Serial.println("Error: UDP send basic info packet failed");
+  if(!modem.socketSend(dataBuf, packet_size)) {
+    Serial.println("Error: UDP send packet failed");
     return false;
   }
 
   /* Attempt to get the latest cell information (for next packet) */
   modem.getCellInformation(WALTER_MODEM_SQNMONI_REPORTS_SERVING_CELL, &rsp);
 
-  Serial.println("UDP send basic info packet succeeded");
+  Serial.println("UDP send basic packet succeeded");
   return true;
 }
 
@@ -334,7 +344,7 @@ void loop()
   if(millis() - lastSend >= sendInterval) {
     lastSend = millis();
 
-    if(!udpSendBasicInfoPacket()) {
+    if(!tcpSendBasicInfoPacket()) {
       Serial.println("UDP send failed, restarting...");
       delay(1000);
       ESP.restart();


### PR DESCRIPTION
It is a known issue that retrieving cellular information from the modem tends to fail if not requested directly after having performed a network request.

This update first validates the cellinfo and then assembles the basic info packet. If the cellinfo is invalid, it just sends a counter packet.

This update will ensure the examples never send invalid (0) cellinfo data to the server.