### PR TITLE
fix(WalterModem): Parser refactor

### DIFF
--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -3413,6 +3413,17 @@ private:
   static bool _getCRLFPosition(const char* rxData, size_t len, size_t* pos = nullptr);
 
   /**
+   * @brief Checks if the current parser buffer contains a predefined end-of-payload marker.
+   *
+   * end-of-payload markers: "\r\nOK\r\n", "\r\nERROR\r\n", or "\r\n+CME ERROR: ".
+   * If found, the payload is segmented, optional CRLF is stripped, the buffer is queued,
+   * and any leftover marker bytes are added to a new buffer for further parsing.
+   *
+   * @return true if a complete payload was detected and handled; false otherwise.
+   */
+  static bool _checkPayloadComplete();
+
+  /**
    * @brief Check the parser buffer for a message containing payload data.
    *
    * @return true if addintional payload data is expected, false otherwise.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -3402,12 +3402,15 @@ private:
   static void _queueRxBuffer();
 
   /**
-   * @brief returns the CRLF position
+   * @brief Returns the position of the first encountered `\r` or `\n` character
    *
    * @param data The incoming data buffer.
    * @param len The number of bytes in the rxData buffer.
+   * @param pos (optional) The amount of bytes before the first CRLF (`\r` or `\n`).
+   *
+   * @return true if `\r\n` was found consecutively. false if only one or none where found.
    */
-  static size_t _getCRLFPosition(const char* rxData, size_t len);
+  static bool _getCRLFPosition(const char* rxData, size_t len, size_t* pos = nullptr);
 
   /**
    * @brief Check the parser buffer for a message containing payload data.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -3402,15 +3402,32 @@ private:
   static void _queueRxBuffer();
 
   /**
-   * @brief Returns the position of the first encountered `\r` or `\n` character
+   * @brief Returns the position of the first CRLF character(s) in a buffer.
    *
-   * @param data The incoming data buffer.
-   * @param len The number of bytes in the rxData buffer.
-   * @param pos (optional) The amount of bytes before the first CRLF (`\r` or `\n`).
+   * This function searches the buffer for carriage return (`\r`) and/or line feed (`\n`)
+   * characters. Its behavior depends on the `findWhole` parameter:
    *
-   * @return true if `\r\n` was found consecutively. false if only one or none where found.
+   * - If `findWhole` is false:
+   *     - Finds the first occurrence of either `\r` or `\n`.
+   *     - Sets `pos` to the index of that first character (if provided).
+   *     - Returns true only if a `\r\n` pair occurs consecutively starting at the first `\r`.
+   *
+   * - If `findWhole` is true:
+   *     - Searches for the first full `\r\n` pair.
+   *     - Sets `pos` to the index of the `\r` in that pair (if provided).
+   *     - Returns true if a full `\r\n` pair is found, false otherwise.
+   *
+   * @param rxData Pointer to the incoming data buffer.
+   * @param len Number of bytes in the rxData buffer.
+   * @param findWhole Whether to search for the full "\r\n" pair (true) or just the first CR or LF
+   * (false).
+   * @param pos Optional pointer to store the position of the first found character or pair. Will be
+   *            set to SIZE_MAX if nothing is found.
+   *
+   * @return true if a "\r\n" pair is found (according to the mode), false otherwise.
    */
-  static bool _getCRLFPosition(const char* rxData, size_t len, size_t* pos = nullptr);
+  static bool _getCRLFPosition(const char* rxData, size_t len, bool findWhole,
+                               size_t* pos = nullptr);
 
   /**
    * @brief Checks if the current parser buffer contains a predefined end-of-payload marker.

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -3426,15 +3426,6 @@ private:
    */
   static void _parseRxData(char* rxData, size_t len);
 
-  /**
-   * @brief This function resets the payload receiving flags.
-   */
-  static void _resetParseRxFlags();
-  /**
-   * @brief This function checks if a full payload was received, if so it queues it and sends the
-   * appropriate return RX command.
-   */
-  static bool _checkPayloadComplete();
 #ifdef ARDUINO
   /**
    * @brief Handle and parse modem RX data.


### PR DESCRIPTION
Issue originated with +LPGNSSASSISTANCE causing hangs at random intervals.

<img width="1767" height="537" alt="image" src="https://github.com/user-attachments/assets/0be5d5c8-7b8d-4797-a31d-381224bc9ca9" />

_parseRxData was not capable of "stitching" multiple parts of a single response buffer together which caused irregular responses being queued.
This refactor aims to fix that problem and make the parser overall more reliable and readable

Key improvements:
- Removed recursion
- Binary payload with a defined size are no longer at risk of being interpreted as CRLF / end-of-payload markers.
- Unknown payload sizes (like +SQNSNVR) do not provide their length and still use `_checkPayloadComplete()`.
- Unexpected CR/LF characters are appended to the queued buffer, but otherwise ignored.
- Messages get added to the queue buffer in 'chunks' between every CR/LF character. The buffer will only queue when a full CRLF pair is found, and all payload was appended.