### PR TITLE
Add Discord announcement workflow for releases

### DIFF
--- a/.github/workflows/discord-release-announcement.yml
+++ b/.github/workflows/discord-release-announcement.yml
@@ -1,0 +1,114 @@
+name: Discord announcement on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  discord_announcement:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Discord message
+        shell: bash
+        env:
+          TITLE_NAME: "Arduino WalterModem"
+          WEBHOOK_URL: ${{ secrets.DISCORD_ANNOUNCEMENTS_WEBHOOK_URL }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          wrap_markdown_urls() {
+            local input="$1"
+            local output=""
+            local i=0
+            local len=${#input}
+
+            while (( i < len )); do
+              if [[ "${input:i:2}" == "](" && ( "${input:i+2:7}" == "http://" || "${input:i+2:8}" == "https://" ) ]]; then
+                # append ']('
+                output+="${input:i:2}"
+                i=$((i+2))
+                output+="<"
+                local depth=1
+                while (( i < len && depth > 0 )); do
+                  local c="${input:i:1}"
+                  if [[ "$c" == "(" ]]; then
+                    depth=$((depth+1))
+                  elif [[ "$c" == ")" ]]; then
+                    depth=$((depth-1))
+                    if (( depth == 0 )); then
+                      output+=">"
+                      output+="$c"
+                      i=$((i+1))
+                      break
+                    fi
+                  fi
+                  output+="$c"
+                  i=$((i+1))
+                done
+              else
+                output+="${input:i:1}"
+                i=$((i+1))
+              fi
+            done
+
+            echo "$output"
+          }
+
+          MESSAGE=$(printf "%s\n" \
+            "# New $TITLE_NAME release: $RELEASE_NAME" \
+            "- **TAG:** $RELEASE_TAG" \
+            "- **URL:** <$RELEASE_URL>" \
+            "" \
+            "---" \
+            "$RELEASE_BODY"
+          )
+
+          # Wrap URLs inside markdown links with <> to prevent discord auto-embed
+          MESSAGE=$(wrap_markdown_urls "$MESSAGE")
+
+          MAX_LEN=2000
+
+          send_message() {
+            local msg="$1"
+            local payload
+            payload=$(jq -n --arg content "$msg" '{content: $content}')
+            curl -s -H "Content-Type: application/json" -X POST -d "$payload" "$WEBHOOK_URL"
+          }
+
+          split_and_send() {
+            local remaining="$1"
+
+            while [ "${#remaining}" -gt "$MAX_LEN" ]; do
+              local chunk="${remaining:0:$MAX_LEN}"
+              local split_at
+
+              split_at=$(awk -v str="$chunk" '
+                BEGIN {
+                  pos = 0;
+                  for (i = 1; i <= length(str); i++) {
+                    if (substr(str, i, 1) == "\n") {
+                      pos = i;
+                    }
+                  }
+                  print pos;
+                }'
+              )
+
+              if [ "$split_at" -eq 0 ]; then
+                split_at=$MAX_LEN
+              fi
+
+              local part="${remaining:0:$split_at}"
+              send_message "$part"
+              remaining="${remaining:$split_at}"
+            done
+
+            if [ -n "$remaining" ]; then
+              send_message "$remaining"
+            fi
+          }
+
+          split_and_send "$MESSAGE"


### PR DESCRIPTION
This workflow sends a Discord message when a new release is published, including details like release name, tag, URL, and body.

It will split the release body over multiple messages if the maximum content length of discord is reached.
It will encapsulate markdown-style urls with <> to prevent discord from auto-generating embeds.