### PR TITLE
fix(WalterModem): Retrieving ICCID and eUICCID using getSIMCardID()

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -1647,18 +1647,15 @@ void WalterModem::_processQueueRsp(WalterModemCmd* cmd, WalterModemBuffer* buff)
       if(inICCID) {
         if(buff->data[i] == '"' || offset >= 22) {
           cmd->rsp->data.simCardID.iccid[offset] = '\0';
-          i += 3;
-
-          if(offset >= 22) {
-            break;
-          } else {
-            continue;
-          }
+          inICCID = false;
+          offset = 0;
+          i += 2; 
+          continue;
         }
 
         cmd->rsp->data.simCardID.iccid[offset++] = buff->data[i];
       } else {
-        if(buff->data[i] == '"' || offset >= 22) {
+        if(buff->data[i] == '"' || offset >= 32) {
           cmd->rsp->data.simCardID.euiccid[offset] = '\0';
           break;
         }

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -1707,7 +1707,7 @@ typedef struct {
   /**
    * @brief A 0-terminated string representation of the SIM eUICCID.
    */
-  char euiccid[23];
+  char euiccid[33];
 } WalterModemSIMCardID;
 
 /**


### PR DESCRIPTION
Fixed incorrect length and interpretation of the ICCID and eUICCID when using getSIMCardID().

While a ICCID is typically 18 to 22 digits long, an eUICCID (EID) is always 32 digits long.

The modem responds to the command (_AT+SQNCCID_) with: +SQNCCID:"**[ICCID]**","**[eUICCID]**" so we match the double quotes to extract the ICCID and eUICCID values.