### PR TITLE
fix(mqtt): add missing lteConnect call in mqtts example

### DIFF
--- a/examples/mqtts/mqtts.ino
+++ b/examples/mqtts/mqtts.ino
@@ -438,6 +438,11 @@ void setup()
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);
 
+  if(!lteConnect()) {
+      Serial.println("Error: LTE connect failed");
+      return;
+  }
+  
   /* Set up the TLS profile */
   if(setupTLSProfile()) {
     Serial.println("TLS Profile setup succeeded");

--- a/examples/mqtts/mqtts.ino
+++ b/examples/mqtts/mqtts.ino
@@ -438,16 +438,17 @@ void setup()
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);
 
-  if(!lteConnect()) {
-      Serial.println("Error: LTE connect failed");
-      return;
-  }
-  
   /* Set up the TLS profile */
   if(setupTLSProfile()) {
     Serial.println("TLS Profile setup succeeded");
   } else {
     Serial.println("Error: TLS Profile setup failed");
+    return;
+  }
+
+  /* Connect to the cellular network */
+  if(!lteConnect()) {
+    Serial.println("Error: LTE connect failed");
     return;
   }
 


### PR DESCRIPTION
mqtts example no longer worked since version 1.5.
lteConnect function was missing.