### PR TITLE
fix(mqtt): add missing lteConnect call in aws_mqtt example

### DIFF
--- a/examples/aws_mqtt/aws_mqtt.ino
+++ b/examples/aws_mqtt/aws_mqtt.ino
@@ -438,6 +438,12 @@ void setup()
     return;
   }
 
+  /* Connect to the cellular network */
+  if(!lteConnect()) {
+    Serial.println("Error: LTE connect failed");
+    return;
+  }
+
   /* Configure MQTT with TLS profile (MQTTS) */
   if(modem.mqttConfig(AWS_MQTTS_CLIENT_ID, 0, 0, AWS_MQTT_TLS_PROFILE)) {
     Serial.println("MQTTS configuration succeeded");

--- a/examples/mqtts/mqtts.ino
+++ b/examples/mqtts/mqtts.ino
@@ -438,6 +438,11 @@ void setup()
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);
 
+  if(!lteConnect()) {
+      Serial.println("Error: LTE connect failed");
+      return;
+  }
+  
   /* Set up the TLS profile */
   if(setupTLSProfile()) {
     Serial.println("TLS Profile setup succeeded");

--- a/examples/mqtts/mqtts.ino
+++ b/examples/mqtts/mqtts.ino
@@ -438,16 +438,17 @@ void setup()
   /* Set the MQTT event handler */
   modem.setMQTTEventHandler(myMQTTEventHandler, NULL);
 
-  if(!lteConnect()) {
-      Serial.println("Error: LTE connect failed");
-      return;
-  }
-  
   /* Set up the TLS profile */
   if(setupTLSProfile()) {
     Serial.println("TLS Profile setup succeeded");
   } else {
     Serial.println("Error: TLS Profile setup failed");
+    return;
+  }
+
+  /* Connect to the cellular network */
+  if(!lteConnect()) {
+    Serial.println("Error: LTE connect failed");
     return;
   }
 


### PR DESCRIPTION
aws_mqtt example no longer worked since version 1.5.
lteConnect function was missing.