### PR TITLE
fix(cell-info): widen cellInformation.nc to uint16_t for 3-digit MNCs

### DIFF
--- a/src/WalterModem.cpp
+++ b/src/WalterModem.cpp
@@ -2364,7 +2364,7 @@ void WalterModem::_processModemRSP(WalterModemCmd* cmd, WalterModemBuffer* buff)
           if(strncmp("Cc", key, key_len) == 0) {
             strToUint16(value, value_len, &(cmd->rsp->data.cellInformation.cc));
           } else if(strncmp("Nc", key, key_len) == 0) {
-            strToUint8(value, value_len, &(cmd->rsp->data.cellInformation.nc));
+            strToUint16(value, value_len, &(cmd->rsp->data.cellInformation.nc));
           } else if(strncmp("RSRP", key, key_len) == 0) {
             strToFloat(value, value_len, &(cmd->rsp->data.cellInformation.rsrp));
           } else if(strncmp("CINR", key, key_len) == 0) {

--- a/src/WalterModem.h
+++ b/src/WalterModem.h
@@ -2319,7 +2319,7 @@ typedef struct {
   /**
    * @brief Mobile network operator code.
    */
-  uint8_t nc;
+  uint16_t nc;
 
   /**
    * @brief Reference Signal Received Power.


### PR DESCRIPTION
## Summary
- `WalterModemCellInformation.nc` (Mobile Network Code) is currently `uint8_t`, but MNCs can be 2 **or 3** digits (0-999). Any MNC > 255 is silently truncated by `strToUint8` at parse time in `_processModemRSP`.
- The bundled examples (`tcp/`, `udp/`, `positioning/`, `walter_feels/`) already serialize `nc` as a 16-bit value:
  ```c
  out_buf[N+0] = rsp.data.cellInformation.nc >> 8;
  out_buf[N+1] = rsp.data.cellInformation.nc & 0xFF;
  ```
  Because `uint8_t >> 8` (after integer promotion) is always `0`, the high byte is currently dead and the examples silently break on networks whose MNC exceeds 255.

## Change
Two lines:
- `src/WalterModem.h` — `uint8_t nc;` → `uint16_t nc;`
- `src/WalterModem.cpp` — `strToUint8(...)` → `strToUint16(...)` when parsing the `Nc` key

Examples need no changes; they already do the right thing for a 16-bit value.

## Compatibility notes
- ABI: the `WalterModemCellInformation` struct layout shifts (one extra byte for `nc`, plus any padding before `rsrp`). Users who pin to a release tag are unaffected; users tracking `main` will need to recompile sketches that use `cellInformation`. No source-level API changes.
- Wire format produced by the example sketches: a previously-always-zero byte may now carry data. Receivers of those packets that hard-coded the field as one byte will benefit from the fix; receivers that assumed the high byte was zero padding should treat it as the MNC high byte going forward (which is what the examples' shift code already implies was intended).

## Test plan
- [ ] Build the `positioning` example against the modified library and confirm it still compiles.
- [ ] On a SIM whose MNC is 2 digits, confirm `nc` still parses identically.
- [ ] On a SIM whose MNC is 3 digits (>255), confirm `nc` now holds the full value rather than `value & 0xFF`.